### PR TITLE
Improve preloader performance on non-accelerated platforms

### DIFF
--- a/src/app/theme/sass/_preloader.scss
+++ b/src/app/theme/sass/_preloader.scss
@@ -33,7 +33,6 @@
   height: 100%;
   z-index: 1000;
   background: #000000;
-  backface-visibility: hidden;
   & > div {
     display: block;
     position: relative;
@@ -45,9 +44,7 @@
     border-radius: 50%;
     border: 3px solid transparent;
     border-top-color: $danger;
-    backface-visibility: hidden;
     transform: translate3d(0, 0, 0);
-    backface-visibility: hidden;
     animation: spin 2s linear infinite; /* Chrome, Firefox 16+, IE 10+, Opera */
     &:before {
       content: "";


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Performance fix



* **What is the current behavior?** (You can also link to an open issue here)
Preloader spinner janks on Firefox on Linux on Intel Broadwell 


* **What is the new behavior (if this is a feature change)?**
Preloader spinner spins smoothly


* **Other information**:

Using the backface-visibility property causes 2D elements and transforms
to be elevated to a 3D context. Since the only transform being used is
rotate(Xdeg), which is a 2D transform, there is no need to incur the
extra performance penalty.