### PR TITLE
Changing deprecated ambientDependencies to globalDependencies

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -3,7 +3,7 @@
     "zone.js": "github:gdi2290/typed-zone.js#66ea8a3451542bb7798369306840e46be1d6ec89"
   },
   "devDependencies": {},
-  "ambientDependencies": {
+  "globalDependencies": {
     "core-js": "registry:dt/core-js#0.0.0+20160317120654",
     "hammerjs": "github:DefinitelyTyped/DefinitelyTyped/hammerjs/hammerjs.d.ts#74a4dfc1bc2dfadec47b8aae953b28546cb9c6b7",
     "lodash": "registry:dt/lodash#3.10.0+20160330154726",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
Typings install has no affect!


* **What is the new behavior (if this is a feature change)?**
Typings install will do its job! :)


* **Other information**:

Using "typings install" has no function because ambientDependencies is deprecated.
With globalDependencies, typings install does its job again! :-)