### PR TITLE
Make source map files generated correctly.

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -80,7 +80,7 @@ module.exports = webpackMerge(commonConfig, {
      *
      * See: http://webpack.github.io/docs/configuration.html#output-sourcemapfilename
      */
-    sourceMapFilename: '[name].map',
+    sourceMapFilename: '[file].map',
 
     /** The filename of non-entry chunks as relative path
      * inside the output.path directory.

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -72,7 +72,7 @@ module.exports = webpackMerge(commonConfig, {
      *
      * See: http://webpack.github.io/docs/configuration.html#output-sourcemapfilename
      */
-    sourceMapFilename: '[name].[chunkhash].bundle.map',
+    sourceMapFilename: '[file].map',
 
     /**
      * The filename of non-entry chunks as relative path


### PR DESCRIPTION
- **What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

    Bug Fix

- **What is the current behavior? (You can also link to an open issue here)**

    The generated source map file for main.bundle.js only contains the following incorrect content.

> {"version":3,"sources":[],"names":[],"mappings":"","file":"initial.css","sourceRoot":""}

- **What is the new behavior (if this is a feature change)?**

    The whole source mappings will be produced properly.

- **Other information:**

    https://github.com/webpack/extract-text-webpack-plugin/issues/119