### PR TITLE
fixing navigation issue - creating deep copy of routes before working on

### DIFF
--- a/src/app/theme/components/baSidebar/baSidebar.component.ts
+++ b/src/app/theme/components/baSidebar/baSidebar.component.ts
@@ -3,6 +3,7 @@ import {AppState} from '../../../app.state';
 import {layoutSizes} from '../../../theme';
 import {BaMenu} from '../baMenu';
 import {routes} from '../../../../app/app.routes';
+import * as _ from 'lodash';
 
 @Component({
   selector: 'ba-sidebar',
@@ -15,7 +16,7 @@ import {routes} from '../../../../app/app.routes';
 export class BaSidebar {
 
   // here we declare which routes we want to use as a menu in our sidebar
-  public routes = routes;
+  public routes = _.cloneDeep(routes); // we're creating a deep copy since we are going to change that object
 
   public menuHeight:number;
   public isMenuCollapsed:boolean = false;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixing navigation issue

* **What is the current behavior?** (You can also link to an open issue here)

When creating the menu form the routes objects, the routes object shouldn't be changed since the next time it will be used by the menu, it will be corrupted.  

* **What is the new behavior (if this is a feature change)?**
Creating a clone of the routes object before changing it.


* **Other information**:
issue 93 describes the problem.