### PR TITLE
Routes To Menus decoupling support

### DIFF
--- a/src/app/theme/components/baMenu/baMenu.service.ts
+++ b/src/app/theme/components/baMenu/baMenu.service.ts
@@ -41,12 +41,17 @@ export class BaMenuService {
       let menuItem;
       if (item.skip) {
         if (item.children && item.children.length > 0) {
-          menuItem = item.children;
+          for(let i=0;i<item.children.length;i++){
+            if(item.children[i].route.dontShowChildren){
+              delete item.children[i].children;
+              menuItem=item;
+            }else
+              menuItem=item.children;
+          }
         }
       } else {
         menuItem = item;
       }
-
       if (menuItem) {
         menu.push(menuItem);
       }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature/Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Pages children routes definition with parameter support are not working


* **What is the new behavior (if this is a feature change)?**
Pages children routes definition with parameter support are working
Additionally, it is possible to define route children without showing them in the sidebar

* **Other information**:

Adding the boolean parameter "dontShowChildren" to a pages route, it won't be shown in the sidebar. 
This makes possible children routes definition with parameter support, that previously wasn't working.
For example:

{
path: 'mypath',
component: MyComponent,
data: {
          menu: {myMenuData}
        },
        dontShowChildren:true,
        children: [
          { path: '', component: MyChildrenComponent },
          { path: ':id', component: MyChildComponent }
        ]
}