### PR TITLE
Remove extensions from imports/exports

### DIFF
--- a/src/app/theme/components/baAmChart/index.ts
+++ b/src/app/theme/components/baAmChart/index.ts
@@ -1,1 +1,1 @@
-export * from './baAmChart.component.ts';
+export * from './baAmChart.component';

--- a/src/app/theme/components/baBackTop/index.ts
+++ b/src/app/theme/components/baBackTop/index.ts
@@ -1,1 +1,1 @@
-export * from './baBackTop.component.ts';
+export * from './baBackTop.component';

--- a/src/app/theme/components/baChartistChart/index.ts
+++ b/src/app/theme/components/baChartistChart/index.ts
@@ -1,1 +1,1 @@
-export * from './baChartistChart.component.ts';
+export * from './baChartistChart.component';

--- a/src/app/theme/components/baContentTop/index.ts
+++ b/src/app/theme/components/baContentTop/index.ts
@@ -1,1 +1,1 @@
-export * from './baContentTop.component.ts';
+export * from './baContentTop.component';

--- a/src/app/theme/components/baFullCalendar/index.ts
+++ b/src/app/theme/components/baFullCalendar/index.ts
@@ -1,1 +1,1 @@
-export * from './baFullCalendar.component.ts';
+export * from './baFullCalendar.component';

--- a/src/app/theme/components/baMenu/index.ts
+++ b/src/app/theme/components/baMenu/index.ts
@@ -1,1 +1,1 @@
-export * from './baMenu.component.ts';
+export * from './baMenu.component';

--- a/src/app/theme/components/baMsgCenter/index.ts
+++ b/src/app/theme/components/baMsgCenter/index.ts
@@ -1,1 +1,1 @@
-export * from './baMsgCenter.component.ts';
+export * from './baMsgCenter.component';

--- a/src/app/theme/components/baPageTop/index.ts
+++ b/src/app/theme/components/baPageTop/index.ts
@@ -1,1 +1,1 @@
-export * from './baPageTop.component.ts';
+export * from './baPageTop.component';

--- a/src/app/theme/components/baPictureUploader/index.ts
+++ b/src/app/theme/components/baPictureUploader/index.ts
@@ -1,1 +1,1 @@
-export * from './baPictureUploader.component.ts';
+export * from './baPictureUploader.component';

--- a/src/app/theme/components/baSidebar/index.ts
+++ b/src/app/theme/components/baSidebar/index.ts
@@ -1,1 +1,1 @@
-export * from './baSidebar.component.ts';
+export * from './baSidebar.component';

--- a/src/app/theme/directives/baScrollPosition/index.ts
+++ b/src/app/theme/directives/baScrollPosition/index.ts
@@ -1,1 +1,1 @@
-export * from './baScrollPosition.directive.ts';
+export * from './baScrollPosition.directive';

--- a/src/app/theme/directives/baSlimScroll/index.ts
+++ b/src/app/theme/directives/baSlimScroll/index.ts
@@ -1,1 +1,1 @@
-export * from './baSlimScroll.directive.ts';
+export * from './baSlimScroll.directive';

--- a/src/app/theme/directives/baThemeRun/index.ts
+++ b/src/app/theme/directives/baThemeRun/index.ts
@@ -1,1 +1,1 @@
-export * from './baThemeRun.directive.ts';
+export * from './baThemeRun.directive';

--- a/src/app/theme/pipes/baAppPicture/index.ts
+++ b/src/app/theme/pipes/baAppPicture/index.ts
@@ -1,1 +1,1 @@
-export * from './baAppPicture.pipe.ts';
+export * from './baAppPicture.pipe';

--- a/src/app/theme/pipes/baKameleonPicture/index.ts
+++ b/src/app/theme/pipes/baKameleonPicture/index.ts
@@ -1,1 +1,1 @@
-export * from './baKameleonPicture.pipe.ts';
+export * from './baKameleonPicture.pipe';

--- a/src/app/theme/pipes/baProfilePicture/index.ts
+++ b/src/app/theme/pipes/baProfilePicture/index.ts
@@ -1,1 +1,1 @@
-export * from './baProfilePicture.pipe.ts';
+export * from './baProfilePicture.pipe';

--- a/src/app/theme/services/baThemePreloader/index.ts
+++ b/src/app/theme/services/baThemePreloader/index.ts
@@ -1,1 +1,1 @@
-export * from './baThemePreloader.service.ts';
+export * from './baThemePreloader.service';


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
I'm using Visual Studio & Resharper, and some imports/exports weren't recognized. 
Changing them to not include .ts extension fixes this.

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
