### PR TITLE
Update ng2-smart-table to fix an issue related to module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ng2-bootstrap": "1.1.0",
     "ng2-tree": "^0.0.2-7",
     "ng2-ckeditor": "1.0.6",
-    "ng2-smart-table": "^0.1.6",
+    "ng2-smart-table": "^0.2.3",
     "ng2-uploader": "0.5.14",
     "normalize.css": "^4.1.1",
     "rxjs": "5.0.0-beta.6",

--- a/src/app/pages/tables/tables.module.ts
+++ b/src/app/pages/tables/tables.module.ts
@@ -1,10 +1,11 @@
-import { NgModule }      from '@angular/core';
-import { CommonModule }  from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { NgaModule } from '../../theme/nga.module';
+import { NgModule }            from '@angular/core';
+import { CommonModule }        from '@angular/common';
+import { FormsModule }         from '@angular/forms';
+import { Ng2SmartTableModule } from 'ng2-smart-table';
+import { NgaModule }           from '../../theme/nga.module';
 
-import { routing }       from './tables.routing';
-import { Tables } from './tables.component';
+import { routing }     from './tables.routing';
+import { Tables }      from './tables.component';
 import { BasicTables } from './components/basicTables/basicTables.component';
 import { SmartTables } from './components/smartTables/smartTables.component';
 
@@ -13,6 +14,7 @@ import { SmartTables } from './components/smartTables/smartTables.component';
   imports: [
     CommonModule,
     FormsModule,
+    Ng2SmartTableModule,
     NgaModule,
     routing
   ],


### PR DESCRIPTION
Hi,

In using the master branch, I found issues about SmartTable and module introduced by Angular 2.rc5. I tried to update the package [ng2-smart-table](https://github.com/akveo/ng2-smart-table) and the issue is gone. However, I updated to the version 0.2.3 but it doesn't exist on the repo of the project.

Thanks.
