### PR TITLE
Rudimentary support for electron

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -17,7 +17,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const METADATA = {
   title: 'ng2-admin - Angular 2 Admin Template',
   description: 'Free Angular 2 and Bootstrap 4 Admin Template',
-  baseUrl: '/'
+  baseUrl: './'
 };
 
 /*

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -17,7 +17,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const METADATA = {
   title: 'ng2-admin - Angular 2 Admin Template',
   description: 'Free Angular 2 and Bootstrap 4 Admin Template',
-  baseUrl: './'
+  baseUrl: './',
   isDevServer: helpers.isWebpackDevServer()
 };
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "compression-webpack-plugin": "^0.3.1",
     "es6-promise": "^3.1.2",
     "es6-shim": "^0.35.0",
-    "es7-reflect-metadata": "^1.6.0"
+    "es7-reflect-metadata": "^1.6.0",
+    "electron": "^1.3.4"
   },
   "scripts": {
     "rimraf": "rimraf",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
     "start": "npm run server:dev",
     "start:hmr": "npm run server:dev:hmr",
     "version": "npm run build",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "electron": "electron ./src/electron/main.js"
   },
   "repository": {
     "type": "git",

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -1,0 +1,53 @@
+const electron = require('electron')
+// Module to control application life.
+const app = electron.app
+// Module to create native browser window.
+const BrowserWindow = electron.BrowserWindow
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow
+
+function createWindow () {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({width: 800, height: 600})
+
+  // and load the index.html of the app.
+  mainWindow.loadURL(`file://${__dirname}/../../dist/index.html`)
+
+  // Open the DevTools.
+  mainWindow.webContents.openDevTools()
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow()
+  }
+})
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Based on #96, and because I want to use this wonderful project as the basis for a new electron app, I implemented a rudimentary wrapper for electron as a POC. I will extend this functionality on the electron part to include packaging, optimizations (removing polyfills etc.) later on.
I would suggest creating a feature branch for this, so it can mature further before becoming an integral part of ng2-admin.

* **What is the current behavior?** (You can also link to an open issue here)
ng2-admin runs as a web application.

* **What is the new behavior (if this is a feature change)?**
ng2-admin can now also be run as an electron app.

* **Other information**:
The only change to ng2-admin itself is changing the base href from '/' to './', as electron uses absolute file paths. This change does not affect the normal behavior of the web application.