### PR TITLE
feat(menu): highlight childless items when path matches

### DIFF
--- a/src/app/theme/components/baMenu/baMenu.service.ts
+++ b/src/app/theme/components/baMenu/baMenu.service.ts
@@ -107,7 +107,11 @@ export class BaMenuService {
   }
 
   protected _selectItem(object:any):any {
-    object.selected = object.url == ('#' + this._router.url);
+    if (object.children) {
+      object.selected = object.url === ('#' + this._router.url);
+    } else {
+      object.selected = ('#' + this._router.url).indexOf(object.url) === 0;
+    }
     return object;
   }
 }

--- a/src/app/theme/components/baMenu/baMenu.service.ts
+++ b/src/app/theme/components/baMenu/baMenu.service.ts
@@ -100,6 +100,7 @@ export class BaMenuService {
       object.url = object.url ? object.url : '#' + itemUrl;
 
       object.target = object.target || '';
+      object.pathMatch = object.pathMatch  || 'full';
       return this._selectItem(object);
     }
 
@@ -107,7 +108,7 @@ export class BaMenuService {
   }
 
   protected _selectItem(object:any):any {
-    if (object.children) {
+    if (object.children || object.pathMatch === 'full') {
       object.selected = object.url === ('#' + this._router.url);
     } else {
       object.selected = ('#' + this._router.url).indexOf(object.url) === 0;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature


* **What is the current behavior?** (You can also link to an open issue here)
Url has to fully match for the element to get highlighted.


* **What is the new behavior (if this is a feature change)?**
Childless menu items are highlighted when the beginning of the current url matches with their url.


* **Other information**:
PR for issue #254. I changed the condition based on which the elements are highlighted.
I've done some testing. I removed all children from the _UI Features_ menu item and it worked as intended - the element was highlighted when I accessed that route's children (/buttons, /grid, /typography).

As for the second change I mentioned in the issue, it isn't needed since RC5, as then you guys split routing and menu apart and now you can just remove children from _pages.menu.ts_, so no need for filtering.