### PR TITLE
feat(forms): add example selects with valid styling

### DIFF
--- a/src/app/pages/forms/components/inputs/components/selectInputs/index.ts
+++ b/src/app/pages/forms/components/inputs/components/selectInputs/index.ts
@@ -1,0 +1,1 @@
+export * from './selectInputs.component';

--- a/src/app/pages/forms/components/inputs/components/selectInputs/selectInputs.component.ts
+++ b/src/app/pages/forms/components/inputs/components/selectInputs/selectInputs.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'select-inputs',
+  template: require('./selectInputs.html')
+})
+export class SelectInputs {
+  constructor() { }
+}

--- a/src/app/pages/forms/components/inputs/components/selectInputs/selectInputs.html
+++ b/src/app/pages/forms/components/inputs/components/selectInputs/selectInputs.html
@@ -1,0 +1,21 @@
+<div class="form-group">
+  <label for="exampleSelect1">Example select</label>
+  <select class="form-control" id="exampleSelect1">
+    <option>1</option>
+    <option>2</option>
+    <option>3</option>
+    <option>4</option>
+    <option>5</option>
+  </select>
+</div>
+
+<div class="form-group">
+  <label for="exampleSelect2">Example multiple select</label>
+  <select multiple class="form-control" id="exampleSelect2">
+    <option>1</option>
+    <option>2</option>
+    <option>3</option>
+    <option>4</option>
+    <option>5</option>
+  </select>
+</div>

--- a/src/app/pages/forms/components/inputs/inputs.html
+++ b/src/app/pages/forms/components/inputs/inputs.html
@@ -10,7 +10,11 @@
         <group-inputs></group-inputs>
       </ba-card>
 
+      <ba-card title="Selects" baCardClass="with-scroll">
+        <select-inputs></select-inputs>
+      </ba-card>
     </div>
+
     <div class="col-md-6">
       <ba-card title="Validation States" baCardClass="with-scroll">
         <validation-inputs></validation-inputs>

--- a/src/app/pages/forms/forms.module.ts
+++ b/src/app/pages/forms/forms.module.ts
@@ -15,6 +15,7 @@ import { ValidationInputs } from './components/inputs/components/validationInput
 import { GroupInputs } from './components/inputs/components/groupInputs';
 import { CheckboxInputs } from './components/inputs/components/checkboxInputs';
 import { Rating } from './components/inputs/components/ratinginputs';
+import { SelectInputs } from './components/inputs/components/selectInputs';
 
 import { InlineForm } from './components/layouts/components/inlineForm';
 import { BlockForm } from './components/layouts/components/blockForm';
@@ -39,6 +40,7 @@ import { WithoutLabelsForm } from './components/layouts/components/withoutLabels
     GroupInputs,
     CheckboxInputs,
     Rating,
+    SelectInputs,
     InlineForm,
     BlockForm,
     HorizontalForm,

--- a/src/app/theme/sass/_form.scss
+++ b/src/app/theme/sass/_form.scss
@@ -58,6 +58,14 @@ select.form-control {
   padding-left: 8px;
 }
 
+select.form-control:not([multiple]) option {
+  color: $dropdown-text;
+}
+
+select.form-control[multiple] option {
+  color: $default-text;
+}
+
 textarea.form-control {
   height: 96px;
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
There are no select dropdowns on the _form inputs_ page. The select dropdown options have invalid colors, which makes them unusable without additional styling.
![Invalid option styles](https://i.gyazo.com/6e61f5530a704beb96f7b26457c64b5c.png)


* **What is the new behavior (if this is a feature change)?**
Add a new card to the _form inputs_ page presenting two types of select dropdowns, allowing for single and multiple options selection. Options are now correctly styled.
![Single value select dropdown](https://i.gyazo.com/693763fee5ad15b56b4ad7ecc4e2d8f7.png)
![Multiple value select dropdown](https://i.gyazo.com/f18df82fefc85fedeb3589b1a215dbe6.png)


* **Other information**:

I tried to mimic how other components are added to the panel. Let me know if there's anything wrong.

Related to issue #282