### PR TITLE
fix(menu): prevent extra '/' in menu link for empty path string

### DIFF
--- a/src/app/theme/components/baMenu/baMenu.service.ts
+++ b/src/app/theme/components/baMenu/baMenu.service.ts
@@ -80,7 +80,7 @@ export class BaMenuService {
       item.route.paths = item.route.path;
     } else {
       item.route.paths = parent && parent.route && parent.route.paths ? parent.route.paths.slice(0) : ['/'];
-      item.route.paths.push(item.route.path);
+      if (!!item.route.path) item.route.paths.push(item.route.path);
     }
 
     if (object.children && object.children.length > 0) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Menu item link contains extra '/' for empty string path component. Please see https://github.com/akveo/ng2-admin/issues/364.


* **What is the new behavior (if this is a feature change)?**
Prevent extra '/'.


* **Other information**:
n/a
