### PR TITLE
fix(sidebar): add href attribute to placeholder links in sidebar and …

### DIFF
--- a/src/app/theme/components/baMenu/components/baMenuItem/baMenuItem.html
+++ b/src/app/theme/components/baMenu/components/baMenuItem/baMenuItem.html
@@ -8,7 +8,7 @@
     <i *ngIf="menuItem.icon" class="{{ menuItem.icon }}"></i><span>{{ menuItem.title }}</span>
   </a>
 
-  <a *ngIf="menuItem.children" (mouseenter)="onHoverItem($event, item)" (click)="onToggleSubMenu($event, menuItem)" class="al-sidebar-list-link">
+  <a *ngIf="menuItem.children" (mouseenter)="onHoverItem($event, item)" href (click)="onToggleSubMenu($event, menuItem)" class="al-sidebar-list-link">
     <i *ngIf="menuItem.icon" class="{{ menuItem.icon }}"></i><span>{{ menuItem.title }}</span>
     <b class="fa fa-angle-down" [ngClass]="{'fa-angle-up': menuItem.expanded}"></b>
   </a>

--- a/src/app/theme/components/baPageTop/baPageTop.component.ts
+++ b/src/app/theme/components/baPageTop/baPageTop.component.ts
@@ -22,6 +22,7 @@ export class BaPageTop {
   public toggleMenu() {
     this.isMenuCollapsed = !this.isMenuCollapsed;
     this._state.notifyDataChanged('menu.isCollapsed', this.isMenuCollapsed);
+    return false;
   }
 
   public scrolledChanged(isScrolled) {

--- a/src/app/theme/components/baPageTop/baPageTop.html
+++ b/src/app/theme/components/baPageTop/baPageTop.html
@@ -1,7 +1,7 @@
 <div class="page-top clearfix" baScrollPosition maxHeight="50" (scrollChange)="scrolledChanged($event)"
      [ngClass]="{scrolled: isScrolled}">
   <a routerLink="/pages/dashboard" class="al-logo clearfix"><span>ng2-</span>admin</a>
-  <a (click)="toggleMenu()" class="collapse-menu-link ion-navicon"></a>
+  <a href (click)="toggleMenu()" class="collapse-menu-link ion-navicon"></a>
 
   <div class="search">
     <i class="ion-ios-search-strong" ng-click="startSearch()"></i>


### PR DESCRIPTION
Because bootstrap4 introduces placeholder links https://github.com/twbs/bootstrap/issues/19402 , some of links we have in our admin panel without `href` attribute are being overrided by following css:
```css
a:not([href]):not([tabindex]) {
  color: inherit;
  text-decoration: none;
}
```
This specifically breaks expand/collapse menuitems in sidebar and expand/collapse control in pageTop component in mint version.