### PR TITLE
fix(breadcrumbs): breadcrumbs color in mint theme should not be the s…

### DIFF
--- a/src/app/theme/components/baContentTop/baContentTop.scss
+++ b/src/app/theme/components/baContentTop/baContentTop.scss
@@ -32,7 +32,7 @@ h1.al-title {
     }
 
     &.breadcrumb-item.active {
-      color: $default;
+      color: $default-text;
     }
   }
 }


### PR DESCRIPTION
In mint theme breadcrumbs are being rendered with white, that's why they're not visible on background.