### PR TITLE
adding auto generated .js and .js.map files to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ npm-debug.log
 # IDE #
 .idea/
 *.swp
+/src/**/*.js
+/src/**/*.js.map
+ng2-admin.iml


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:

When developing in Intellij or WebStorm IDE, it tsc automatically generate .js and .js.map files in the same level where .ts files are there.
These auto generated files will keep bugging to be committed.

Adding these auto generated files will help developer to concentrated on there work rather looking into unwanted git issue.