### PR TITLE
fix a bug when PORT env exist.

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -17,7 +17,7 @@ const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
  */
 const ENV = process.env.ENV = process.env.NODE_ENV = 'development';
 const HOST = process.env.HOST || 'localhost';
-const PORT = process.env.PORT || 3000;
+const PORT = Number(process.env.PORT) || 3000;
 const HMR = helpers.hasProcessFlag('hot');
 const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
   host: HOST,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

when PORT env variable exist, npm start failed with an error

```
Invalid configuration object. webpack-dev-server has been initialised using a configuration object that does not match the API schema.
 - configuration.port should be a number.
```

* **What is the new behavior (if this is a feature change)?**

this PR fix the issue.

* **Other information**:
