### PR TITLE
Bad linking correction between label and input

### DIFF
--- a/src/app/pages/forms/components/layouts/components/blockForm/blockForm.html
+++ b/src/app/pages/forms/components/layouts/components/blockForm/blockForm.html
@@ -15,7 +15,7 @@
 <div class="row">
   <div class="col-sm-6">
     <div class="form-group">
-      <label for="inputFirstName">Email</label>
+      <label for="inputEmail">Email</label>
       <input type="email" class="form-control" id="inputEmail" placeholder="Email">
     </div>
   </div>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix, now if you click on the label email it will select the right input.

* **What is the current behavior?** (You can also link to an open issue here)

If you click on email label the name input will be selected.