### PR TITLE
Update _blur.scss

### DIFF
--- a/src/app/theme/sass/conf/colorSchemes/_blur.scss
+++ b/src/app/theme/sass/conf/colorSchemes/_blur.scss
@@ -59,7 +59,7 @@ $hoverlink: $primary-dark;
 @mixin body-bg() {
   background-color: $body-bg;
 
-  $mainBgUrl: $images-root + 'blur-bg.jpg';
+  $mainBgUrl: $assets-root + $images-root + 'blur-bg.jpg';
 
   &::before {
     content: '';


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix. Related to issue https://github.com/akveo/ng2-admin/issues/1042

* **What is the current behavior?** (You can also link to an open issue here)
Blur theme bg image is broken. This PR will solve that.

* **What is the new behavior (if this is a feature change)?**
Missing assets_variable has been placed in its location. Same as it is in ng2.scss theme.

* **Other information**:
