### PR TITLE
Fixed error occurring with 'docker build'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:6.9.5
 RUN git clone https://github.com/akveo/ng2-admin.git /var/www \
     && cd /var/www \
     && npm install --global rimraf \
-    && npm run clean \
+    && npm run clean:dist \
     && npm install --global webpack webpack-dev-server typescript@2.1.5 \
     && npm install \
     && npm run prebuild:prod && npm run build:prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN git clone https://github.com/akveo/ng2-admin.git /var/www \
 EXPOSE 8080
 
 WORKDIR /var/www
-ENTRYPOINT ["npm", "run", "server:prod"]
+ENTRYPOINT ["npm", "run", "start:prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM node:6.9.5
 RUN git clone https://github.com/akveo/ng2-admin.git /var/www \
     && cd /var/www \
     && npm install --global rimraf \
-    && npm run clean:dist \
+    && npm run clean \
     && npm install --global webpack webpack-dev-server typescript@2.1.5 \
     && npm install \
-    && npm run prebuild:prod && npm run build:prod
+    && npm run build:prod:aot
 
 EXPOSE 8080
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint:ci": "npm run lint && npm run lint:styles",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "ng e2e",
+    "clean": "npm cache clean && npm run rimraf -- node_modules doc typings coverage dist",
     "clean:dist": "npm run rimraf -- dist",
     "clean:coverage": "npm run rimraf -- coverage",
     "docs:deploy": "wintersmith build -C docs && gh-pages -d docs/build",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix.

**What is the current behavior?**

Running the following command:

 `docker build -t <your username>/node-web-app .`

Produces the following error:

`npm ERR! missing script: clean`
`npm ERR! missing script: prebuild:prod`

**Other information**:

Added `clean` command to **package.json**.
Replaced `prebuild:prod` `build:prod` commands with `build:prod:aot` in **Dockerfile**.
Changed entry point from `server:prod`to `start:prod`
