### PR TITLE
Use relative path for loading the image.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -48,7 +48,7 @@ export class App {
 
   private _loadImages(): void {
     // register some loaders
-    BaThemePreloader.registerLoader(this._imageLoader.load('/assets/img/sky-bg.jpg'));
+    BaThemePreloader.registerLoader(this._imageLoader.load('./assets/img/sky-bg.jpg'));
   }
 
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix. (a potentially bug)

* **What is the current behavior?** (You can also link to an open issue here)

Fails to load sky-bg.jpg in case the app was built with `--base-href`.

* **What is the new behavior (if this is a feature change)?**

Fix the issue above.

* **Other information**:
