### PR TITLE
Fix Bug #1171 (baCard with scrollbar not displaying in IE11)

### DIFF
--- a/src/app/theme/sass/bootstrap-overrides/_card.scss
+++ b/src/app/theme/sass/bootstrap-overrides/_card.scss
@@ -47,7 +47,7 @@ $card-header-font-size: 16px;
     .card-body {
       height: calc(100% - #{$card-title-height});
       overflow-y: auto;
-      flex: 1;
+      flex: 0 1 auto;
     }
   }
 }


### PR DESCRIPTION
Fix Bug #1171 (baCard with scrollbar not displaying in IE11)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
baCards with scrolling are not displayed correctly in IE11.  See bug #1171 


* **What is the new behavior (if this is a feature change)?**
baCards with scrolling are displayed correctly in IE11


* **Other information**:
